### PR TITLE
[JBEAP-18391] [issue-114] EL should coerce String to Integer in equals operation

### DIFF
--- a/impl/src/main/java/com/sun/el/lang/ELSupport.java
+++ b/impl/src/main/java/com/sun/el/lang/ELSupport.java
@@ -136,18 +136,6 @@ public class ELSupport {
         if (obj0 == null || obj1 == null) {
             return false;
         }
-        if (obj0 instanceof Boolean || obj1 instanceof Boolean) {
-            return coerceToBoolean(obj0).equals(coerceToBoolean(obj1));
-        }
-        if (obj0.getClass().isEnum()) {
-            return obj0.equals(coerceToEnum(obj1, obj0.getClass()));
-        }
-        if (obj1.getClass().isEnum()) {
-            return obj1.equals(coerceToEnum(obj0, obj1.getClass()));
-        }
-        if (obj0 instanceof String || obj1 instanceof String) {
-            return coerceToString(obj0).equals(coerceToString(obj1));
-        }
         if (isBigDecimalOp(obj0, obj1)) {
             BigDecimal bd0 = (BigDecimal) coerceToNumber(obj0, BigDecimal.class);
             BigDecimal bd1 = (BigDecimal) coerceToNumber(obj1, BigDecimal.class);
@@ -167,9 +155,20 @@ public class ELSupport {
             Long l0 = (Long) coerceToNumber(obj0, Long.class);
             Long l1 = (Long) coerceToNumber(obj1, Long.class);
             return l0.equals(l1);
-        } else {
-            return obj0.equals(obj1);
         }
+        if (obj0 instanceof Boolean || obj1 instanceof Boolean) {
+            return coerceToBoolean(obj0).equals(coerceToBoolean(obj1));
+        }
+        if (obj0.getClass().isEnum()) {
+            return obj0.equals(coerceToEnum(obj1, obj0.getClass()));
+        }
+        if (obj1.getClass().isEnum()) {
+            return obj1.equals(coerceToEnum(obj0, obj1.getClass()));
+        }
+        if (obj0 instanceof String || obj1 instanceof String) {
+            return coerceToString(obj0).equals(coerceToString(obj1));
+        }
+        return obj0.equals(obj1);
     }
 
     /**

--- a/impl/src/test/java/org/glassfish/el/test/OperatorTest.java
+++ b/impl/src/test/java/org/glassfish/el/test/OperatorTest.java
@@ -39,22 +39,14 @@ public class OperatorTest {
     public void setUp() {
     }
     
-    void testExpr(String testname, String expr, Long expected) {
+    void testExpr(String testname, String expr, Object expected) {
         System.out.println("=== Test " + testname + " ===");
         System.out.println(" ** " + expr);
         Object result = elp.eval(expr);
         System.out.println("    returns " + result);
         assertEquals(expected, result);
     }
-    
-    void testExpr(String testname, String expr, String expected) {
-        System.out.println("=== Test " + testname + " ===");
-        System.out.println(" ** " + expr);
-        Object result = elp.eval(expr);
-        System.out.println("    returns " + result);
-        assertEquals(expected, result);
-    }
-    
+
     @Test
     public void testConcat() {
         testExpr("concat", "a = null; b = null; a + b", 0L);
@@ -112,5 +104,14 @@ public class OperatorTest {
                 elm.getELContext(), "${name}", Object.class, new Class[] {});
         m.invoke(elm.getELContext(), null);
         */
+    }
+
+    @Test
+    public void testEquals() {
+        testExpr("string", "'xx' == 'xx'", Boolean.TRUE);
+        testExpr("number", "'a'.length() == 1", Boolean.TRUE);
+        testExpr("coerce '01'", "'01' == 1", Boolean.TRUE);
+        testExpr("coerce '01'", "1 == '01'", Boolean.TRUE);
+        testExpr("coerce '01.10'", "'01.10' == 1.10", Boolean.TRUE);
     }
 }


### PR DESCRIPTION
Fix for JBEAP-18391. Plain cherry-pick from upstream Issue-114 in [upstream](https://github.com/eclipse-ee4j/el-ri.git) to old UEL repo.

Issue: https://issues.redhat.com/browse/JBEAP-18391
Upstream Issue: https://github.com/eclipse-ee4j/el-ri/issues/114
Upstream PR: https://github.com/eclipse-ee4j/el-ri/pull/115